### PR TITLE
Much and many changes to the segmentation demo

### DIFF
--- a/auto_segmentation_controller.py
+++ b/auto_segmentation_controller.py
@@ -1,0 +1,69 @@
+from auto_segmentation import AutoSegmentation
+
+class AutoSegmentationController:
+    """
+    For the controlling of the UI elements in the View Class and the sending data to the Model class
+    As well as modifying data to communicate between the View and Model Classes
+    """
+
+    def __init__(self, view) -> None:
+        """
+        Initialising the Controller for Auto Segmentation Feature.
+        Creating the requirements to run the feature
+        :param view: AutoSegmentationTab
+        :rtype: None
+        """
+        self._view = view
+        self._model = None
+
+    def set_view(self, view) -> None:
+        """
+        To change the view reference if a new view is
+        constructed to replace the old view
+        :param view:
+        :rtype: None
+        """
+        self._view = view
+
+    # View related methods
+    def start_button_clicked(self) -> None:
+        """
+        To be called when the button to start the selected segmentation task is clicked
+        :rtype: None
+        """
+        self.run_task(self._view.get_segmentation_task(), self._view.get_fast_value())
+
+    def update_progress_bar_value(self, value: int) -> None:
+        """
+        Access the view of the feature and updates the progress bar on the UI element
+        :param value: int
+        :rtype: None
+
+        """
+        self._view.set_progress_bar_value(value)
+
+    def update_progress_text(self, text: str) -> None:
+        """
+        Access the view of the feature and updates the progress text on the UI element
+        :param text: str
+        :rtype: None
+        """
+        self._view.set_progress_text(text)
+
+    # Model related methods
+    def run_task(self, dicom_dir: str, task: str, fast: bool) -> None:
+        """
+        Run the segmentation task from the model class.
+        Performing the Segmentation for the Dicom Images
+        :param task: str
+        :param fast: bool
+        :rtype: None
+        """
+        # Run tasks on separate thread
+
+        # Instantiate AutoSegmentation passing the required settings from the UI
+        auto_segmentation = AutoSegmentation(dicom_dir, task, fast, controller=self)
+        auto_segmentation.run_segmentation_workflow()
+
+        # to run the task in the model class
+        print(f'Running task: {task} with Fast set to {fast}')

--- a/auto_segmentation_ui.py
+++ b/auto_segmentation_ui.py
@@ -1,0 +1,81 @@
+import logging
+import sys
+from redirect_stdout import ConsoleOutputStream
+from auto_segmentation_controller import AutoSegmentationController
+
+from PySide6.QtWidgets import (
+    QApplication,
+    QWidget,
+    QVBoxLayout,
+    QPushButton,
+    QFileDialog,
+    QLabel,
+    QComboBox,
+    QTextEdit
+)
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+class OnkoSegmentationGUI(QWidget):
+    def __init__(self):
+        """Initialize the OnkoSegmentationGUI.
+
+        Sets up the UI elements, including the task selector, run button, and output display,
+        and connects the run button to the segmentation workflow.
+        """
+
+        super().__init__()
+        self.setWindowTitle("OnkoDICOM + TotalSegmentator")
+        self.setGeometry(100, 100, 400, 200)
+        self.controller = AutoSegmentationController(self)
+
+        self.layout = QVBoxLayout()
+
+        # Task dropdown
+        self.layout.addWidget(QLabel("Select Segmentation Type:"))
+        self.task_selector = QComboBox()
+        self.task_selector.addItems([
+            "total", "total_mr", "lung_vessels", "body", "body_mr",
+            "vertebrae_mr", "hip_implant", "pleural_pericard_effusion", "cerebral_bleed",
+            "head_glands_cavities", "head_muscles", "headneck_bones_vessels",
+            "headneck_muscles", "liver_vessels", "oculomotor_muscles",
+            "lung_nodules", "kidney_cysts", "breasts", "liver_segments",
+            "liver_segments_mr", "craniofacial_structures",  "abdominal_muscles"
+        ])
+        self.task_selector.setCurrentText("total")
+        self.layout.addWidget(self.task_selector)
+
+        self.text_edit = QTextEdit()
+        self.text_edit.setReadOnly(True)
+        self.layout.addWidget(self.text_edit)
+
+        # Run button
+        self.run_button = QPushButton("Run Segmentation")
+        self.run_button.clicked.connect(self._run_button_clicked)
+        self.layout.addWidget(self.run_button)
+
+        self.setLayout(self.layout)
+
+    def _run_button_clicked(self):
+        dicom_dir = QFileDialog.getExistingDirectory(self, "Select DICOM CT Series")
+        #     if not dicom_dir:
+        #         return
+        self.controller.run_task(dicom_dir, self.task_selector.currentText(), fast=True)
+
+    def set_progress_text(self, text: str) -> None:
+        """
+        Public Method to set the progress text in the progress text box.
+        To display the text to the user of what is currently being performed,
+        to inform the user as to the current aspect of the task being performed.
+        :param text: str
+        :rtype: None
+        """
+        self.text_edit.append(text)
+
+if __name__ == "__main__":
+    app = QApplication([])
+    sys.stdout = ConsoleOutputStream()
+    window = OnkoSegmentationGUI()
+    window.show()
+    app.exec()

--- a/ignore_files_in_dir.py
+++ b/ignore_files_in_dir.py
@@ -1,0 +1,44 @@
+import tempfile
+import shutil
+import os
+import fnmatch
+
+source_path = "/Users/timglasgow/Downloads/3229478DC190B24900C6F3A1C514AF18.CT.FU" # Replace with your source directory
+exclude_patterns = ["rt*.dcm"]
+
+def ignore_func(directory, contents):
+    ignored_items = []
+    for pattern in exclude_patterns:
+        if pattern.endswith('/'):
+            dir_name = pattern.rstrip('/')
+            if dir_name in contents and os.path.isdir(os.path.join(directory, dir_name)):
+                ignored_items.append(dir_name)
+        elif '*' in pattern or '?' in pattern:
+            ignored_items.extend(
+                item for item in contents if fnmatch.fnmatch(item, pattern)
+            )
+        elif pattern in contents and os.path.isfile(os.path.join(directory, pattern)):
+            ignored_items.append(pattern)
+    return ignored_items
+
+# try:
+#     with tempfile.TemporaryDirectory() as temp_dir:
+#         print(f"Temporary directory created at: {temp_dir}")
+#         shutil.copytree(source_path, temp_dir, ignore=ignore_func, dirs_exist_ok=True)
+#         print(f"Contents of '{source_path}' copied to '{temp_dir}', excluding specified patterns.")
+# 
+#         # You can now work with the contents of temp_dir
+#         # For example, list its contents:
+#         print("\nContents of temporary directory:")
+#         for root, dirs, files in os.walk(temp_dir):
+#             level = root.replace(temp_dir, '').count(os.sep)
+#             indent = ' ' * 4 * (level)
+#             print(f'{indent}{os.path.basename(root)}/')
+#             subindent = ' ' * 4 * (level + 1)
+#             for f in files:
+#                 print(f'{subindent}{f}')
+# 
+# except FileNotFoundError:
+#     print(f"Error: Source path '{source_path}' not found.")
+# except Exception as e:
+#     print(f"An error occurred: {e}")

--- a/multithread.py
+++ b/multithread.py
@@ -1,0 +1,38 @@
+from PySide6.QtCore import (
+    QRunnable,
+    Slot,
+    Signal,
+    QObject,
+)
+
+class WorkerSignals(QObject):
+    finished = Signal()
+
+class Worker(QRunnable):
+    """Worker thread.
+
+    Inherits from QRunnable to handler worker thread setup, signals and wrap-up.
+
+    :param callback: The function callback to run on this worker thread.
+                     Supplied args and kwargs will be passed through to the runner.
+    :type callback: function
+    :param args: Arguments to pass to the callback function
+    :param kwargs: Keywords to pass to the callback function
+    """
+    def __init__(self, fn, *args, **kwargs):
+        super().__init__()
+        self.fn = fn
+        self.args = args
+        self.kwargs = kwargs
+
+        # Create object containing signals
+        self.signals = WorkerSignals()
+
+
+    @Slot()
+    def run(self):
+        """Initialise the runner function with passed args, kwargs."""
+        print('Processing...Please Wait')
+        self.fn(*self.args, **self.kwargs)
+        self.signals.finished.emit()
+        print('Process Complete')

--- a/nifti_converter.py
+++ b/nifti_converter.py
@@ -75,6 +75,7 @@ def nifti_to_rtstruct_conversion(nifti_path: str, dicom_path: str, output_path: 
     """
 
     logging.info("Converting NIfTI to RTStruct...")
+    print("Converting NIfTI to RTStruct...")
 
     try:
         # Validate inputs
@@ -149,14 +150,4 @@ def nifti_to_rtstruct_conversion(nifti_path: str, dicom_path: str, output_path: 
     except Exception as e:
         logging.error(f"An unexpected error occurred: {type(e).__name__}: {e}")
         raise
-
-# TESTING - uses local absolute paths (change to your local paths)
-# if __name__ == "__main__":
-#
-#     # Hard coded variable for testing
-#     dicom_path_in = "/Users/timglasgow/Downloads/3229478DC190B24900C6F3A1C514AF18/3229478DC190B24900C6F3A1C514AF18.CT.FU"
-#     nifti_path_in = "/Users/timglasgow/Downloads/3229478DC190B24900C6F3A1C514AF18/3229478DC190B24900C6F3A1C514AF18.CT.FU/segmentations/"
-#     output_path_in = "/Users/timglasgow/Downloads/3229478DC190B24900C6F3A1C514AF18/3229478DC190B24900C6F3A1C514AF18.CT.FU/rtss.dcm"
-#
-#     nifti_to_rtstruct_conversion(nifti_path_in, dicom_path_in, output_path_in)
 

--- a/nifti_converter_ui.py
+++ b/nifti_converter_ui.py
@@ -14,10 +14,18 @@ from PySide6.QtWidgets import (
 import nifti_converter
 
 class NiftiConverter(QWidget):
+    """Widget for converting NIfTI segmentations to DICOM RTStruct.
+
+    Provides a UI for selecting NIfTI and DICOM directories and
+    initiating the conversion process.
     """
-    WORK IN PROGRESS - Basic UI for Nifti Converter
-    """
+
     def __init__(self):
+        """Initialize the NiftiConverter widget.
+
+        Sets up the UI elements, including labels, buttons, and layouts,
+        and connects the buttons to their respective functions.
+        """
         super().__init__()
 
         self.nifti_path = None

--- a/redirect_stdout.py
+++ b/redirect_stdout.py
@@ -1,0 +1,43 @@
+import logging
+
+from PySide6.QtCore import QObject, Signal
+import sys
+
+
+class ConsoleOutputStream(QObject):
+    """A QObject subclass to redirect console output to a GUI element.
+
+    This class intercepts text written to stdout and emits it as a Qt signal,
+    allowing console output to be displayed in a GUI while maintaining original
+    console visibility.
+    """
+    new_text = Signal(str)
+
+    def write(self, text):
+        self.new_text.emit(text)
+        sys.__stdout__.write(text)  # Also write to original stdout for console visibility
+        sys.__stdout__.flush()
+
+    def flush(self):
+        sys.__stdout__.flush()
+
+def redirect_output_to_gui(console_stream: ConsoleOutputStream):
+    sys.stdout = console_stream
+    # sys.stderr = console_stream  # Redirect stderr too
+
+class QtLogHandler(logging.Handler):
+    """Custom logging handler to emit logs to Qt GUI via ConsoleOutputStream."""
+    def __init__(self, console_stream: ConsoleOutputStream):
+        super().__init__()
+        self.console_stream = console_stream
+
+    def emit(self, record):
+        msg = self.format(record)
+        self.console_stream.new_text.emit(msg + "\n")
+
+def setup_logging(console_stream: ConsoleOutputStream):
+    handler = QtLogHandler(console_stream)
+    handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)

--- a/rtstruct_loader.py
+++ b/rtstruct_loader.py
@@ -1,0 +1,26 @@
+import numpy as np
+from rt_utils import RTStructBuilder
+
+def load_rtstruct_masks(rtstruct_path: str, dicom_series_dir: str) -> dict:
+    """
+    Load binary masks from a DICOM RTSTRUCT and its corresponding CT series.
+
+    :param rtstruct_path: path to DICOM RTSTRUCT file
+    :param dicom_series_dir: path to folder containing the CT series
+    :return: dict of {roi_name: np.ndarray (3D binary mask)}
+    """
+    # Load RTStruct object
+    rtstruct = RTStructBuilder.create_from(
+        dicom_series_path=dicom_series_dir,
+        rt_struct_path=rtstruct_path
+    )
+
+    roi_names = rtstruct.get_roi_names()
+    print("ROI names:", roi_names)
+    masks = {}
+
+    for name in roi_names:
+        mask_3d = rtstruct.get_roi_mask_by_name(name)  # shape: (z, y, x)
+        masks[name] = mask_3d.astype(np.uint8)
+
+    return masks

--- a/simple_matplot_viewer.py
+++ b/simple_matplot_viewer.py
@@ -1,0 +1,248 @@
+import os
+import numpy as np
+import SimpleITK as sitk
+from skimage import measure
+from scipy.ndimage import gaussian_filter1d
+
+from rtstruct_loader import load_rtstruct_masks
+
+
+from PySide6.QtWidgets import (
+    QApplication, QWidget, QVBoxLayout, QHBoxLayout,
+    QPushButton, QFileDialog, QSlider, QComboBox, QCheckBox, QScrollArea, QGroupBox
+)
+from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
+import matplotlib.pyplot as plt
+
+
+class DicomNiftiViewer(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("DICOM + NIfTI Segmentation Viewer")
+
+        # UI Elements
+        self.canvas = FigureCanvas(plt.Figure())
+        self.ax = self.canvas.figure.add_subplot(111)
+        self.slider = QSlider()
+        self.slider.setOrientation(Qt.Orientation.Horizontal)
+        self.slider.valueChanged.connect(self.update_display)
+
+        self.view_selector = QComboBox()
+        self.view_selector.addItems(["Axial", "Coronal", "Sagittal"])
+        self.view_selector.currentIndexChanged.connect(self.update_display)
+
+        self.overlay_checkboxes = []
+        self.overlay_visibility = []
+
+        self.scroll_area = QScrollArea()
+        self.checkbox_container = QVBoxLayout()
+        self.scroll_area.setWidgetResizable(True)
+        checkbox_group = QGroupBox("Segmentations")
+        checkbox_group.setLayout(self.checkbox_container)
+        self.scroll_area.setWidget(checkbox_group)
+
+        # Data holders
+        self.ct_array = None
+        self.seg_arrays = []
+        self.seg_names = []
+        self.seg_colors = []
+        self.spacing = []
+
+        # Layout
+        layout = QVBoxLayout()
+        layout.addWidget(self.canvas)
+        layout.addWidget(self.view_selector)
+        layout.addWidget(self.slider)
+        layout.addWidget(self.scroll_area)
+
+        btn_layout = QHBoxLayout()
+        self.btn_load_dicom = QPushButton("Load DICOM Series")
+        self.btn_load_seg = QPushButton("Load NIfTI Segmentations")
+        self.btn_load_rtstruct = QPushButton("Load RTSTRUCT")
+        self.btn_load_dicom.clicked.connect(self.load_dicom)
+        self.btn_load_seg.clicked.connect(self.load_segmentations)
+        self.btn_load_rtstruct.clicked.connect(self.load_rtstruct)
+        btn_layout.addWidget(self.btn_load_dicom)
+        btn_layout.addWidget(self.btn_load_seg)
+        btn_layout.addWidget(self.btn_load_rtstruct)
+
+        layout.addLayout(btn_layout)
+        self.setLayout(layout)
+
+    def load_dicom(self):
+        folder = QFileDialog.getExistingDirectory(self, "Select DICOM Folder")
+        if not folder:
+            return
+
+        # self.spacing = sitk.ReadImage(files[0]).GetSpacing()
+        # print(self.spacing)
+
+        reader = sitk.ImageSeriesReader()
+        dicom_names = reader.GetGDCMSeriesFileNames(folder)
+        reader.SetFileNames(dicom_names)
+        image = reader.Execute()
+        self.spacing = image.GetSpacing()
+        print(self.spacing)
+        image = sitk.DICOMOrient(image, 'LPS')
+        self.ct_array = sitk.GetArrayFromImage(image)  # (z, y, x)
+        self.slider.setMaximum(self.ct_array.shape[0] - 1)
+        self.update_display()
+
+    def load_segmentations(self) -> None:
+        """
+        Load NIfTI segmentation files.
+
+        Opens a file dialog to select multiple NIfTI segmentation files,
+        reads them using SimpleITK, and stores them for display.
+        It also creates checkboxes for each segmentation file to control visibility.
+
+        """
+
+        files, _ = QFileDialog.getOpenFileNames(self, "Select NIfTI Segmentations", filter="*.nii.gz")
+        if not files:
+            return
+
+        # Clear all previous data
+        self.seg_arrays.clear()
+        self.seg_names.clear()
+        self.seg_colors.clear()
+        self.overlay_visibility.clear()
+
+        for i in reversed(range(self.checkbox_container.count())):
+            self.checkbox_container.itemAt(i).widget().deleteLater()
+
+        base_colors = plt.colormaps['tab20']
+
+        # Iterate over the segmentation files load, add check box, and display
+        for i, file_path in enumerate(files):
+            seg_image = sitk.ReadImage(file_path)
+            seg_image = sitk.DICOMOrient(seg_image, 'LPS')
+            seg_array = sitk.GetArrayFromImage(seg_image).astype(bool)
+            self.seg_arrays.append(seg_array)
+            self.seg_names.append(os.path.basename(file_path))
+            self.seg_colors.append(base_colors(i))
+
+            checkbox = QCheckBox(os.path.basename(file_path))
+            checkbox.setChecked(True)
+            checkbox.stateChanged.connect(self.update_display)
+            self.overlay_checkboxes.append(checkbox)
+            self.overlay_visibility.append(True)
+            self.checkbox_container.addWidget(checkbox)
+
+        self.update_display()
+
+    def load_rtstruct(self):
+        rtstruct_path, _ = QFileDialog.getOpenFileName(self, "Select RTSTRUCT File", filter="*.dcm")
+        if not rtstruct_path:
+            return
+
+        dicom_dir = QFileDialog.getExistingDirectory(self, "Select CT DICOM Folder")
+        if not dicom_dir:
+            return
+
+        mask_dict = load_rtstruct_masks(rtstruct_path, dicom_dir)
+
+        self.seg_arrays.clear()
+        self.seg_names.clear()
+        self.seg_colors.clear()
+        self.overlay_visibility.clear()
+
+        # Clear old checkboxes
+        for i in reversed(range(self.checkbox_container.count())):
+            self.checkbox_container.itemAt(i).widget().deleteLater()
+
+        base_colors = plt.colormaps['tab20']
+
+        for i, (name, mask) in enumerate(mask_dict.items()):
+            self.seg_arrays.append(mask.astype(bool))
+            self.seg_names.append(name)
+            self.seg_colors.append(base_colors(i))
+
+            checkbox = QCheckBox(name)
+            checkbox.setChecked(True)
+            checkbox.stateChanged.connect(self.update_display)
+            self.overlay_checkboxes.append(checkbox)
+            self.overlay_visibility.append(True)
+            self.checkbox_container.addWidget(checkbox)
+
+        self.slider.setMaximum(self.ct_array.shape[0] - 1)
+        self.update_display()
+
+    def update_display(self):
+        self.ax.clear()
+        if self.ct_array is None:
+            return
+
+        view = self.view_selector.currentText()
+        axis = {"Axial": 0, "Coronal": 1, "Sagittal": 2}[view]
+
+        if axis == 0:
+            max_idx = self.ct_array.shape[0] - 1
+            print(max_idx)
+        elif axis == 1:
+            max_idx = self.ct_array.shape[1] - 1
+            print(max_idx)
+        else:
+            max_idx = self.ct_array.shape[2] - 1
+            print(max_idx)
+
+        self.slider.setMaximum(max_idx)
+        idx = self.slider.value()
+
+        if axis == 0: # axial
+            base_slice = self.ct_array[idx, :, :]
+            pix_aspect = self.spacing[0]
+        elif axis == 1: # coronal
+            base_slice = self.ct_array[:, idx, :]
+            pix_aspect = self.spacing[2]
+        else: # sagittal
+            base_slice = self.ct_array[:, :, idx]
+            pix_aspect = self.spacing[2]
+
+        self.ax.imshow(base_slice, cmap='gray', aspect=pix_aspect, interpolation='nearest')
+
+        for i, seg_array in enumerate(self.seg_arrays):
+            visible = self.overlay_checkboxes[i].isChecked()
+            if not visible:
+                continue
+
+            if idx < seg_array.shape[axis]:
+                if axis == 0:
+                    mask_slice = seg_array[idx, :, :].astype(float)
+                elif axis == 1:
+                    mask_slice = seg_array[:, idx, :].astype(float)
+                else:
+                    mask_slice = seg_array[:, :, idx].astype(float)
+
+                # Find contours at mask boundary 0.5
+                contours = measure.find_contours(mask_slice, 0.5)
+                rgba = self.seg_colors[i]
+
+                for contour in contours:
+                    # Smooth contour coordinates
+                    x = contour[:, 1]
+                    y = contour[:, 0]
+
+                    # Gaussian smoothing
+                    x_smooth = gaussian_filter1d(x, sigma=0.8)
+                    y_smooth = gaussian_filter1d(y, sigma=1.3)
+
+                    # Plot filled polygon with transparency
+                    self.ax.fill(x_smooth, y_smooth, color=rgba, alpha=0.3)
+
+                    # Optionally plot the contour edge
+                    # self.ax.plot(x_smooth, y_smooth, color=rgba, linewidth=1.0)
+
+        self.ax.set_title(f"{view} View - Slice {idx}")
+        self.canvas.draw()
+
+
+if __name__ == "__main__":
+    import sys
+    from PySide6.QtCore import Qt
+
+    app = QApplication(sys.argv)
+    viewer = DicomNiftiViewer()
+    viewer.resize(1000, 800)
+    viewer.show()
+    sys.exit(app.exec())


### PR DESCRIPTION
MVC structure implemented
Multithreading implemented - both total segmentator and conversion run on separate thread to main 
Created simple matplot view uses dicom series and nifti images- not yet working for rtstruct loading

## Summary by Sourcery

Restructure the auto-segmentation demo into an MVC architecture with multithreading, GUI-integrated logging, and temporary DICOM handling, and add a new Matplotlib-based viewer for DICOM and segmentation overlays.

New Features:
- Implement MVC structure by separating UI (auto_segmentation_ui.py), controller, and model (AutoSegmentation)
- Add multithreading for segmentation and conversion tasks using Worker and QThreadPool
- Redirect console output and logs into the GUI via ConsoleOutputStream and a QtLogHandler
- Copy DICOM files to a temporary directory with an ignore function before running segmentation
- Introduce simple_matplot_viewer for interactive display of DICOM series, NIfTI segmentations, and RTSTRUCT overlays

Enhancements:
- Refactor AutoSegmentation workflow into modular methods with progress updates and error handling
- Add detailed docstrings and UI feedback in nifti_converter_ui.py and auto_segmentation_ui.py
- Minor logging addition in nifti_converter to print conversion start